### PR TITLE
[codex] simplify about page

### DIFF
--- a/source/about/index.md
+++ b/source/about/index.md
@@ -3,6 +3,5 @@ title: About
 date: 2024-05-24 23:32:26
 type: about
 ---
-# About Me
 
 Hey! Welcome to my personal space, where I occasionally post random stuff:) Currently, I'm a worker at Microsoft. Before that, I worked as an engineer at Flexport and later at Paulson Institute's think tank, MacroPolo, where I conducted research on geopolitics and trade. I graduated from University of Michigan in 2022 where I studied Computer Science.

--- a/themes/oranges/layout/post.ejs
+++ b/themes/oranges/layout/post.ejs
@@ -34,11 +34,6 @@
         <div class="markdown-body">
           <%- page.content %>
         </div>
-        <figure>
-          <img src="/images/uploads/profile.jpg" alt="Profile Picture" class="right-image">
-          <figcaption class="about-caption">Photo took at Paulson Institute in Chicago, Illinois, April 2024</figcaption>
-        </figure>
-        
       </div>
     </div>
   <% } %>

--- a/themes/oranges/source/css/base.css
+++ b/themes/oranges/source/css/base.css
@@ -27,26 +27,9 @@ body.hidden {
   color: var(--color-text-md-content)
 }
 
-.about-body {
-  display:flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.about-body img.right-image {
-  width: 325px;
-  margin: 20px auto;
-  height: auto; /* Ensure the image doesn't overflow the container */
-}
-
 @media (max-width: 768px) {
   .markdown-body {
     font-size: 1.4rem;
-  }
-
-  .about-body {
-    display: block;
-    text-align: center;
   }
 }
 
@@ -103,11 +86,25 @@ a:hover {
   margin: 0 auto;
 }
 
+.about-index {
+  width: 90%;
+  max-width: 680px;
+}
+
+.about-body {
+  display: block;
+}
+
+.about-index .markdown-body {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 24px 0 56px;
+}
+
 .index .post-list,
 .friend-index .friend-list,
 .archives .post-list,
-.tag-index .tag-list,
-.about-index .markdown-body {
+.tag-index .tag-list {
   padding: 0 40px;
 }
 
@@ -126,8 +123,7 @@ a:hover {
   .index .post-list,
   .friend-index .friend-list,
   .archives .post-list,
-  .tag-index .tag-list,
-  .about-index .markdown-body {
+  .tag-index .tag-list {
     padding: 0;
   }
   .category-index .category-list {
@@ -185,16 +181,9 @@ a:hover {
   .index .post-list,
   .friend-index .friend-list,
   .archives .post-list,
-  .tag-index .tag-list,
-  .about-index .markdown-body {
+  .tag-index .tag-list {
     padding: 0 20px;
   }
-
-  .about-body{
-    display: block;
-    text-align: center;
-  }
-
 }
 
 .post-item {
@@ -768,11 +757,6 @@ a:hover {
 
 .moment-figcaption {
   display: none;
-}
-
-.about-caption {
-  background-color: transparent;
-  color: var(--color-text-md-content);
 }
 
 .sr-only {


### PR DESCRIPTION
## What changed

- remove the profile image and its caption from the About page
- remove the in-page `About Me` heading
- replace the former image-and-copy layout with a centered single-column introduction
- constrain the page to a 680px container and 640px reading width with responsive spacing
- remove CSS that only supported the deleted profile image and caption

## Why

The About page no longer needs a portrait-led layout. The new layout keeps the existing Oranges theme while giving the short introduction a clearer reading width and more deliberate whitespace.

## Validation

- `npm run clean`
- `npm run build`
- verified generated `public/about/index.html` contains no profile image, figure, caption, or H1
- verified the generated About copy and responsive theme styles remain intact
